### PR TITLE
model grc20

### DIFF
--- a/examples/gno.land/r/labs/grc20/gnomod.toml
+++ b/examples/gno.land/r/labs/grc20/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/labs/grc20"
+gno = "0.9"

--- a/examples/gno.land/r/labs/grc20/grc20.gno
+++ b/examples/gno.land/r/labs/grc20/grc20.gno
@@ -1,0 +1,26 @@
+package grc20
+
+// REVIEW: conversion to julia w/ Algebraic Petri Nets
+// https://gist.github.com/stackdump/33dcd8e6f071d391c998008dfeac6ed9
+
+// interactive
+var pflowLink = "[![pflow](https://pflow.dev/img/zb2rhabZZ4tZqhXeHZ9koFufakZ8bBGoMG9VS8HJaUTaUn8hE.svg)](https://pflow.dev/p/zb2rhabZZ4tZqhXeHZ9koFufakZ8bBGoMG9VS8HJaUTaUn8hE/)"
+
+func Render(path string) string {
+    m := GRC20(map[string]any{})
+    return pflowLink + "\n\n" + m.Markdown()
+}
+
+/*
+func (tok Token) RenderHome() string {
+    return ufmt.Sprintf(`# %s ($%s)
+* **Version**: v0
+* **Decimals**: %d
+* **Total supply**: %d
+* **Known accounts**: %d
+* **Model digest**: %s
+* **Proof digest**: %s
+`, tok.name, tok.symbol, tok.decimals, tok.ledger.totalSupply, tok.KnownAccounts(),
+   tok.ModelDigest(), tok.ProofDigest())
+}
+*/

--- a/examples/gno.land/r/labs/grc20/metamodel.gno
+++ b/examples/gno.land/r/labs/grc20/metamodel.gno
@@ -1,0 +1,127 @@
+package grc20
+
+import (
+    mm "gno.land/p/labs/metamodel"
+)
+
+const (
+    Version = "v0"
+
+    // Objects
+    Token = "$token"
+    Allow = "$allow"
+)
+
+// GRC20 returns a single model that matches GRC20 semantics.
+func GRC20(opts map[string]any) *mm.Model {
+    // Helper to get integer options with defaults
+    getIntOpt := func(key string, def int) int {
+        if v, ok := opts[key]; ok {
+            if i, ok := v.(int); ok {
+                return i
+            }
+        }
+        return def
+    }
+
+    // Objects
+    objects := []string{Token, Allow}
+
+    objectModel := mm.New(objects)
+
+    // Tunables
+    transferAmt := int64(getIntOpt("transfer_amount", 10))
+    approveAmt := int64(getIntOpt("approve_amount", 400))
+    spendAmt := int64(getIntOpt("spend_amount", 100))
+    mintAmt := int64(getIntOpt("mint_amount", 5))
+    burnAmt := int64(getIntOpt("burn_amount", 2))
+
+    // Initial values
+    ownerInit := mm.T(getIntOpt("owner_balance", 1100))
+    recipientInit := mm.T(getIntOpt("recipient_balance", 0))
+    allowInit := mm.T(getIntOpt("allowance_initial", 0))
+    minterInit := mm.T(getIntOpt("minter_initial", 1))
+    supplyInit := mm.T(getIntOpt("supply_initial", 0))
+
+places := map[string]mm.Place{
+    "$owner":               {Initial: ownerInit, X: 43, Y: 266},
+    "$recipient":           {Initial: recipientInit, X: 782, Y: 442},
+    "$spender":             {Initial: mm.T(1), X: 44, Y: 443},
+    "$allow(owner->spender)": {Initial: allowInit, X: 525, Y: 275},
+    "$supply":              {Initial: supplyInit, X: 513, Y: 111},
+    "$burned":              {Initial: mm.T(0), X: 764, Y: 111},
+    "$minter":              {Initial: minterInit, X: 50, Y: 113},
+    "$void":                {Initial: mm.T(0), X: 941, Y: 274},
+}
+
+transitions := map[string]mm.Transition{
+    "transfer":       {X: 349, Y: 444},
+    "approveAdd":     {X: 345, Y: 277},
+    "approveZero":    {X: 680, Y: 275},
+    "transferFrom":   {X: 619, Y: 444},
+    "spendAllowance": {X: 799, Y: 275},
+    "mint":           {X: 347, Y: 185},
+    "burn":           {X: 345, Y: 113},
+}
+
+arrows := []mm.Arrow{
+    objectModel.Arrow(mm.Arc{Source: "$owner", Target: "transfer", Weight: transferAmt, Object: Token}),
+    objectModel.Arrow(mm.Arc{Source: "transfer", Target: "$recipient", Weight: transferAmt, Object: Token}),
+    objectModel.Arrow(mm.Arc{Source: "$owner", Target: "approveAdd", Weight: approveAmt, Object: Allow}),
+    objectModel.Arrow(mm.Arc{Source: "approveAdd", Target: "$allow(owner->spender)", Weight: approveAmt, Object: Allow}),
+    objectModel.Arrow(mm.Arc{Source: "$allow(owner->spender)", Target: "approveZero", Weight: spendAmt, Object: Allow}),
+    objectModel.Arrow(mm.Arc{Source: "approveZero", Target: "$void", Weight: spendAmt, Object: Allow}),
+    objectModel.Arrow(mm.Arc{Source: "$owner", Target: "transferFrom", Weight: transferAmt, Object: Token}),
+    objectModel.Arrow(mm.Arc{Source: "$allow(owner->spender)", Target: "transferFrom", Weight: transferAmt, Object: Allow}),
+    objectModel.Arrow(mm.Arc{Source: "transferFrom", Target: "$recipient", Weight: transferAmt, Object: Token}),
+    objectModel.Arrow(mm.Arc{Source: "$allow(owner->spender)", Target: "spendAllowance", Weight: spendAmt, Object: Allow}),
+    objectModel.Arrow(mm.Arc{Source: "spendAllowance", Target: "$void", Weight: spendAmt, Object: Allow}),
+    objectModel.Arrow(mm.Arc{Source: "mint", Target: "$minter", Inhibit: true, Object: Allow}),
+    objectModel.Arrow(mm.Arc{Source: "mint", Target: "$owner", Weight: mintAmt, Object: Token}),
+    objectModel.Arrow(mm.Arc{Source: "mint", Target: "$supply", Weight: mintAmt, Object: Token}),
+    objectModel.Arrow(mm.Arc{Source: "$owner", Target: "burn", Weight: burnAmt, Object: Token}),
+    objectModel.Arrow(mm.Arc{Source: "$supply", Target: "burn", Weight: burnAmt, Object: Token}),
+    objectModel.Arrow(mm.Arc{Source: "burn", Target: "$burned", Weight: burnAmt, Object: Token}),
+    objectModel.Arrow(mm.Arc{Source: "transferFrom", Target: "$spender", Inhibit: true, Object: Allow}),
+}
+
+    // Return the model
+    return mm.New(
+        objects,
+        places,
+        transitions,
+        arrows,
+        map[string]any{"version": Version, "name": "GRC20"},
+    )
+}
+
+/*
+Categorical view of `$allow(owner->spender)`
+
+- Implementation note:
+    We model Allow(o,s) as its own place named "$allow(owner->spender)" — a
+    discrete-index view of the profunctor. A colored-token variant would store
+    pairs (o,s) as token color in a single "$allow" place; the current layout is
+    a clear, didactic approximation.
+
+- Profunctor (enriched in the commutative monoid (N,+,0)):
+    Allow : Addr^op × Addr -> (N,+,0)
+    Each pair (owner, spender) maps to a natural-number allowance.
+    The map is a sparse matrix representation of this profunctor.
+
+- Pointwise (natural) operations:
+    ApproveAdd(o,s,a):   Allow(o,s) += a
+    ApproveZero(o,s):    Allow(o,s)  = 0
+    SpendAllowance(o,s,a): Allow(o,s) = max(Allow(o,s) - a, 0)
+
+- Atomic TransferFrom:
+    Requires Token(o) and Allow(o,s) as simultaneous inputs, and produces Token(r).
+    Effect: Token moves owner->recipient by 'a' while Allow(o,s) decreases by 'a'
+    in the same transition. This is the categorical “commuting square” that
+    enforces atomicity.
+
+- Yoneda-ish slices:
+    Fix owner o:   Allow(o, -) : Addr -> (N,+,0)   (copresheaf: budgets by spender)
+    Fix spender s: Allow(-, s) : Addr^op -> (N,+,0) (presheaf: who grants me how much)
+
+*/

--- a/examples/gno.land/r/labs/home/index.gno
+++ b/examples/gno.land/r/labs/home/index.gno
@@ -3,7 +3,8 @@ package home
 var index = `
 
 ## Labs Index
-- [Grc000](/r/labs/grc000)
+- [grc000](/r/labs/grc000) - base grammar for fungible tokens (GRC-000)
+- [grc20](/r/labs/grc20) - grammar for fungible tokens (GRC-20)
 `
 
 func Render(_ string) string {


### PR DESCRIPTION
This pull request introduces a new GRC-20 token grammar example for the Gno.land labs, including a metamodel implementation and updates to the labs index. 

### New GRC-20 Token Example

* Added `grc20.gno` and `metamodel.gno` in `examples/gno.land/r/labs/grc20`, implementing the GRC-20 token model using a Petri net-based metamodel. This includes detailed logic for token transfers, approvals, minting, and burning, as well as comments explaining the categorical modeling approach. [[1]](diffhunk://#diff-33a211f5d2f0f0551daffb2f9cd430f8e24d1bbbd3ec9a23f5b56291f1e3d64dR1-R26) [[2]](diffhunk://#diff-a781078773e5342bffd280410380f12f98a172d1c49d600379f3ea821c4a3985R1-R127)
